### PR TITLE
Documenting that Canvas.drawArc() requires the first argument `oval` …

### DIFF
--- a/src/skia/Canvas.cpp
+++ b/src/skia/Canvas.cpp
@@ -1609,6 +1609,14 @@ canvas
         If :py:class:`Rect` oval is empty or sweepAngle is zero, nothing is
         drawn.
 
+        NOTE: `oval` should be normalized, so that `oval.fLeft` is less than `oval.fRight`
+        and `oval.fTop` is less than `oval.fBottom`. If unsure, call its `makeSorted()` method.
+        This method differs from `drawOval`, which does not requires such
+        preprocessing. Upstream `drawOval` calls `makeSorted()` internally,
+        but upstream `drawArc` does not; this difference is likely to avoid
+        ambiguity in interpreting `startAngle` and `sweepAngle` in various backends,
+        where drawing direction matters.
+
         :param skia.Rect oval: :py:class:`Rect` bounds of oval containing arc to
             draw
         :param float startAngle: angle in degrees where arc begins


### PR DESCRIPTION
…to be normalised.

Canvas.drawArc() differs from Canvas.drawOval(), in that the latter upstream internally calls makeSorted().

See
    chrome/m144:src/core/SkCanvas.cpp: line 2842 in SkCanvas::drawArc(const SkRect& oval, ...)
    ...
        this->onDrawArc(oval, ...)
    ...
but
    chrome/m144:src/core/SkCanvas.cpp: line 1722 in SkCanvas::drawOval(const SkRect& r, ...)
    ...
        this->onDrawOval(r.makeSorted(),...)

Fixes #201

Credits to @kimssammwu for providing the insight.